### PR TITLE
fix: SearchPostResponse에 createdAt 빌드 추가

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/post/PostService.java
+++ b/memento/src/main/java/com/memento/server/api/service/post/PostService.java
@@ -289,6 +289,7 @@ public class PostService {
 		// === 최종 Response ===
 		return SearchPostResponse.builder()
 			.id(post.getId())
+			.createdAt(post.getCreatedAt())
 			.author(PostAuthor.builder()
 				.id(post.getAssociate().getId())
 				.imageUrl(post.getAssociate().getProfileImageUrl())


### PR DESCRIPTION
## #️⃣ Issue Number

- 관련 깃헙 이슈 번호 기입

Resolves #123 

## 📝 요약(Summary)

변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

post 조회 응답에 createdAt이 null이어서 mapToSearchPostResponse에 createdAt 추가했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

통합 테스트 결과

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/73e50c76-55df-4dc9-b0bd-e9e730f698bb" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
