### PR TITLE
fix: SSE 발생 시 associate의 emitter 사용

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/achievement/AchievementService.java
+++ b/memento/src/main/java/com/memento/server/api/service/achievement/AchievementService.java
@@ -6,11 +6,9 @@ import org.springframework.stereotype.Service;
 
 import com.memento.server.api.controller.achievement.dto.SearchAchievementResponse;
 import com.memento.server.api.service.achievement.dto.SearchAchievementDto;
+import com.memento.server.client.sse.SseEmitterRepository;
 import com.memento.server.common.error.ErrorCodes;
 import com.memento.server.common.exception.MementoException;
-import com.memento.server.domain.achievement.Achievement;
-import com.memento.server.domain.achievement.AchievementAssociate;
-import com.memento.server.domain.achievement.AchievementAssociateRepository;
 import com.memento.server.domain.achievement.AchievementRepository;
 import com.memento.server.domain.achievement.CommonAchievementEvent;
 import com.memento.server.domain.community.Associate;
@@ -25,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 public class AchievementService {
 	private final AssociateRepository associateRepository;
 	private final AchievementRepository achievementRepository;
-	private final AchievementEventPublisher achievementEventPublisher;
+	private final SseEmitterRepository sseEmitterRepository;
 
 	public Associate validAssociate(Long communityId, Long associateId){
 		Associate associate = associateRepository.findByIdAndDeletedAtNull(associateId)
@@ -61,7 +59,11 @@ public class AchievementService {
 	public void create(Long associateId, String content) {
 		switch (content){
 			case "HOME":
-				achievementEventPublisher.publishCommonAchievement(CommonAchievementEvent.from(associateId, 15L));
+			try{
+					sseEmitterRepository.get(associateId).send(CommonAchievementEvent.from(associateId, 15L));
+				} catch (Exception e){	
+					System.out.println("SSE send error: " + e.getMessage());
+				}
 				break;
 			default:
 				throw new MementoException(ErrorCodes.ACHIEVEMENT_NOT_EXISTENCE);

--- a/memento/src/main/java/com/memento/server/client/sse/SseEmitterRepository.java
+++ b/memento/src/main/java/com/memento/server/client/sse/SseEmitterRepository.java
@@ -11,6 +11,7 @@ public class SseEmitterRepository {
 	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
 	public void save(Long associateId, SseEmitter emitter){
+		System.out.println("SseEmitterRepository save: " + associateId);
 		emitters.put(associateId, emitter);
 	}
 


### PR DESCRIPTION
## #️⃣ Issue Number

- 관련 깃헙 이슈 번호 기입

#92 

## 📝 요약(Summary)

변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

SSE를 클라이언트에게 송신하지 못한 버그 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

업적 달성 API 테스트 시 업적은 획득되지만, SSE 메시지는 받지 못했습니다.

확인해보니 SseEmitterRepository의 emitters를 사용하고 있지 않았습니다.

https://github.com/mmt-12/back-end/commit/fe09056cf7cd0caece2f42021af8756214221a1f

sse emitter 가져와서 전송하도록 수정했습니다. 

작동만 확인했고 자세한 코드는 다듬어주십시오 !

## 📸스크린샷 (선택)

스웨거 테스트 결과 등

<img width="1716" height="948" alt="Screenshot 2025-09-25 at 12 13 21 AM" src="https://github.com/user-attachments/assets/ef916ee2-2abf-4d71-9f14-28c21f89a795" />


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
