### PR TITLE
feat : 포스트 이미지 중복 처리 로직 변경

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/post/PostService.java
+++ b/memento/src/main/java/com/memento/server/api/service/post/PostService.java
@@ -376,8 +376,8 @@ public class PostService {
 		}
 
 		List<PostImage> existingImages = postImageRepository.findAllByHashInAndDeletedAtIsNull(hashes);
-		Map<Hash, PostImage> existingMap = existingImages.stream()
-			.collect(Collectors.toMap(PostImage::getHash, image -> image));
+		Map<Hash, List<PostImage>> existingMap = existingImages.stream()
+			.collect(Collectors.groupingBy(PostImage::getHash));
 
 		Map<Hash, PostImage> hashToImage = new HashMap<>();
 
@@ -386,9 +386,8 @@ public class PostService {
 			Hash hash = hashes.get(i);
 
 			if (existingMap.containsKey(hash)) {
-				hashToImage.putIfAbsent(hash, existingMap.get(hash));
 				images.add(PostImage.builder()
-					.url(existingMap.get(hash).getUrl())
+					.url(existingMap.get(hash).get(0).getUrl())
 					.post(post)
 					.hash(hash)
 					.build());

--- a/memento/src/main/java/com/memento/server/domain/post/Hash.java
+++ b/memento/src/main/java/com/memento/server/domain/post/Hash.java
@@ -2,6 +2,8 @@ package com.memento.server.domain.post;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
@@ -18,4 +20,17 @@ public class Hash {
 
 	@Column(name = "hash", length = 255, nullable = false)
 	private String hash;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof Hash)) return false;
+		Hash other = (Hash) o;
+		return Objects.equals(this.hash, other.hash);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hash);
+	}
 }

--- a/memento/src/main/java/com/memento/server/domain/post/PostImageRepository.java
+++ b/memento/src/main/java/com/memento/server/domain/post/PostImageRepository.java
@@ -45,8 +45,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
 	List<PostImage> findAllByPostIdInAndDeletedAtNull(List<Long> postIds);
 
-	List<PostImage> findAllByHashInAndDeletedAtIsNull(List<Hash> hashes);
-
 	@Query("""
         SELECT COUNT(pi)
         FROM PostImage pi
@@ -54,4 +52,6 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
         AND pi.deletedAt IS NULL
     """)
 	int countByAssociateId(@Param("associateId") Long associateId);
+
+	List<PostImage> findAllByHashInAndDeletedAtIsNull(List<Hash> hashes);
 }

--- a/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
@@ -612,6 +612,8 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
 		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file3 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file4 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
 
 		String url = "https://example.com/test.png";
 		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
@@ -620,11 +622,11 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		String content = "test";
 
 		// when
-		postService.create(community.getId(), memory.getId(), associate.getId(), content, List.of(file1, file2));
+		postService.create(community.getId(), memory.getId(), associate.getId(), content, List.of(file1, file2, file3, file4));
 
 		// then
 		List<PostImage> savedImages = postImageRepository.findAll();
-		assertThat(savedImages).hasSize(2);
+		assertThat(savedImages).hasSize(4);
 		String firstUrl = savedImages.get(0).getUrl();
 		String secondUrl = savedImages.get(1).getUrl();
 		assertThat(firstUrl).isEqualTo(secondUrl);
@@ -656,6 +658,8 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
 		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file3 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file4 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
 
 		String url = "https://example.com/test.png";
 		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
@@ -666,10 +670,11 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		// when
 		postService.create(community.getId(), memory.getId(), associate.getId(), content, List.of(file1));
 		postService.create(community.getId(), memory.getId(), associate.getId(), content, List.of(file2));
+		postService.create(community.getId(), memory.getId(), associate.getId(), content, List.of(file3));
 
 		// then
 		List<PostImage> savedImages = postImageRepository.findAll();
-		assertThat(savedImages).hasSize(2);
+		assertThat(savedImages).hasSize(3);
 		String firstUrl = savedImages.get(0).getUrl();
 		String secondUrl = savedImages.get(1).getUrl();
 		assertThat(firstUrl).isEqualTo(secondUrl);

--- a/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
@@ -2,9 +2,16 @@ package com.memento.server.spring.api.service.post;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
+
+import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -575,7 +582,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("중복 이미지는 저장된 이미지 url을 사용한다")
-	public void createHashTest() {
+	public void createHashTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -592,15 +599,17 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Memory memory = MemoryFixtures.memory(event);
 		memoryRepository.save(memory);
 
-		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
-		String url1 = "https://example.com/test1.png";
-		given(minioService.createFile(file1, MinioProperties.FileType.POST))
-			.willReturn(url1);
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
 
-		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
-		String url2 = "https://example.com/test2.png";
-		given(minioService.createFile(file2, MinioProperties.FileType.POST))
-			.willReturn(url2);
+		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
+		String url = "https://example.com/test.png";
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
+			.willReturn(url);
 
 		String content = "test";
 
@@ -616,8 +625,8 @@ public class PostServiceTest extends IntegrationsTestSupport {
 	}
 
 	@Test
-	@DisplayName(" 저장된 이미지 url을 사용한다")
-	public void createDuplicateTest() {
+	@DisplayName("저장된 이미지 url을 사용한다")
+	public void createDuplicateTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -634,15 +643,17 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Memory memory = MemoryFixtures.memory(event);
 		memoryRepository.save(memory);
 
-		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
-		String url1 = "https://example.com/test1.png";
-		given(minioService.createFile(file1, MinioProperties.FileType.POST))
-			.willReturn(url1);
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
 
-		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
-		String url2 = "https://example.com/test2.png";
-		given(minioService.createFile(file2, MinioProperties.FileType.POST))
-			.willReturn(url2);
+		MultipartFile file1 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+		MultipartFile file2 = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
+		String url = "https://example.com/test.png";
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
+			.willReturn(url);
 
 		String content = "test";
 

--- a/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/service/post/PostServiceTest.java
@@ -484,7 +484,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("포스트 생성")
-	public void createTest() {
+	public void createTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -501,9 +501,15 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Memory memory = MemoryFixtures.memory(event);
 		memoryRepository.save(memory);
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
 		String url = "https://example.com/test.png";
-		given(minioService.createFile(file, MinioProperties.FileType.POST))
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
 			.willReturn(url);
 
 		String content = "test";
@@ -671,7 +677,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("포스트 수정")
-	public void updateTest(){
+	public void updateTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -688,9 +694,15 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Memory memory = MemoryFixtures.memory(event);
 		memoryRepository.save(memory);
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
 		String url = "https://example.com/test.png";
-		given(minioService.createFile(file, MinioProperties.FileType.POST))
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
 			.willReturn(url);
 
 		String content = "change";
@@ -709,7 +721,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("다른 참여자의 포스트는 수정할 수 없다")
-	public void updateWithDifferentAssociateTest(){
+	public void updateWithDifferentAssociateTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -729,9 +741,15 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Memory memory = MemoryFixtures.memory(event);
 		memoryRepository.save(memory);
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
 		String url = "https://example.com/test.png";
-		given(minioService.createFile(file, MinioProperties.FileType.POST))
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
 			.willReturn(url);
 
 		String content = "change";
@@ -746,7 +764,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("포스트 삭제")
-	public void deleteTest() {
+	public void deleteTest() throws IOException {
 		// given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -766,9 +784,15 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Post post = PostFixtures.post(memory, associate);
 		postRepository.save(post);
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
 		String url = "https://example.com/test.png";
-		given(minioService.createFile(file, MinioProperties.FileType.POST))
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
 			.willReturn(url);
 
 		List<PostImage> images = postService.saveImages(post, List.of(file));
@@ -798,7 +822,7 @@ public class PostServiceTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("다른 참여자의 포스트는 삭제할 수 없다")
-	public void deleteWithDifferentAssociateTest(){
+	public void deleteWithDifferentAssociateTest() throws IOException {
 		// given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -821,9 +845,15 @@ public class PostServiceTest extends IntegrationsTestSupport {
 		Post post = PostFixtures.post(memory, associate);
 		postRepository.save(post);
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
+
 		String url = "https://example.com/test.png";
-		given(minioService.createFile(file, MinioProperties.FileType.POST))
+		given(minioService.createFile(any(MultipartFile.class), eq(MinioProperties.FileType.POST)))
 			.willReturn(url);
 
 		List<PostImage> images = postService.saveImages(post, List.of(file));


### PR DESCRIPTION
## #️⃣ Issue Number

- close #137 

## 📝 요약(Summary)

- 포스트 이미지 등록 시 중복 이미지 처리 로직 변경
<img width="766" height="762" alt="image" src="https://github.com/user-attachments/assets/08dcb7ee-d441-4a21-b637-7c6dbd204826" />
이미 저장된 이미지 및 처리 중 중복된 이미지 url 공유 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

스웨거 테스트 결과 등

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
