### PR TITLE
fix : post 수정 시 request.oldPictures String(url)로 변경

### DIFF
--- a/memento/src/docs/asciidoc/api/v1/post/post-update.adoc
+++ b/memento/src/docs/asciidoc/api/v1/post/post-update.adoc
@@ -4,6 +4,7 @@
 ==== HTTP Request
 include::{snippets}/post-update-test/http-request.adoc[]
 include::{snippets}/post-update-test/request-parts.adoc[]
+include::{snippets}/post-update-test/request-part-request-fields.adoc[]
 
 ==== HTTP Response
 include::{snippets}/post-update-test/http-response.adoc[]

--- a/memento/src/main/java/com/memento/server/api/controller/post/dto/UpdatePostRequest.java
+++ b/memento/src/main/java/com/memento/server/api/controller/post/dto/UpdatePostRequest.java
@@ -10,6 +10,6 @@ public record UpdatePostRequest(
 	@Size(max = 510, message = "content는 최대 크기가 510입니다.")
 	String content,
 
-	List<Long> oldPictures
+	List<String> oldPictures
 ) {
 }

--- a/memento/src/main/java/com/memento/server/api/service/post/PostService.java
+++ b/memento/src/main/java/com/memento/server/api/service/post/PostService.java
@@ -87,7 +87,7 @@ public class PostService {
 		Post post = validPost(memoryId, postId);
 
 		Map<Post, List<PostImage>> imagesByPostId = postImageRepository
-			.findAllByPostIdInAndDeletedAtNull(List.of(postId))
+			.findAllByPostIdInAndDeletedAtNullOrderByCreatedAtDesc(List.of(postId))
 			.stream()
 			.collect(Collectors.groupingBy(PostImage::getPost));
 
@@ -109,7 +109,7 @@ public class PostService {
 		List<Long> postIds = posts.stream().limit(size).map(Post::getId).toList();
 
 		Map<Post, List<PostImage>> imagesByPostId = postImageRepository
-			.findAllByPostIdInAndDeletedAtNull(postIds)
+			.findAllByPostIdInAndDeletedAtNullOrderByCreatedAtDesc(postIds)
 			.stream()
 			.collect(Collectors.groupingBy(PostImage::getPost));
 

--- a/memento/src/main/java/com/memento/server/api/service/post/PostService.java
+++ b/memento/src/main/java/com/memento/server/api/service/post/PostService.java
@@ -164,7 +164,7 @@ public class PostService {
 	}
 
 	@Transactional
-	public void update(Long communityId, Long memoryId, Long associateId, Long postId, String content, List<Long> oldPictures, List<MultipartFile> newPictures) {
+	public void update(Long communityId, Long memoryId, Long associateId, Long postId, String content, List<String> oldPictures, List<MultipartFile> newPictures) {
 		Associate associate = validAssociate(communityId, associateId);
 		Post post = validPost(memoryId, postId);
 
@@ -178,7 +178,7 @@ public class PostService {
 
 		List<PostImage> images = postImageRepository.findByPostIdAndDeletedAtNull(postId);
 		List<PostImage> deleteImages = images.stream()
-			.filter(image -> !oldPictures.contains(image.getId()))
+			.filter(image -> !oldPictures.contains(image.getUrl()))
 			.toList();
 
 		for(PostImage image : deleteImages){

--- a/memento/src/main/java/com/memento/server/domain/post/PostImageRepository.java
+++ b/memento/src/main/java/com/memento/server/domain/post/PostImageRepository.java
@@ -43,7 +43,9 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
 	List<PostImage> findByPostIdAndDeletedAtNull(Long postId);
 
-	List<PostImage> findAllByPostIdInAndDeletedAtNull(List<Long> postIds);
+	List<PostImage> findAllByPostIdInAndDeletedAtNull(List<Long> postId);
+
+	List<PostImage> findAllByPostIdInAndDeletedAtNullOrderByCreatedAtDesc(List<Long> postIds);
 
 	@Query("""
         SELECT COUNT(pi)

--- a/memento/src/test/java/com/memento/server/docs/post/PostControllerDocsTest.java
+++ b/memento/src/test/java/com/memento/server/docs/post/PostControllerDocsTest.java
@@ -22,6 +22,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
@@ -37,8 +38,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
 
 import com.memento.server.api.controller.post.PostController;
@@ -470,7 +469,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 
 		UpdatePostRequest request = UpdatePostRequest.builder()
 			.content("수정된 내용")
-			.oldPictures(new ArrayList<>(List.of(1L, 2L, 3L)))
+			.oldPictures(new ArrayList<>(List.of("test1.png", "test2.png", "test3.png")))
 			.build();
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -482,7 +481,7 @@ public class PostControllerDocsTest extends RestDocsSupport {
 		);
 
 		MockMultipartFile file = new MockMultipartFile(
-			"nswPictures",
+			"newPictures",
 			"newImage1.png",
 			"image/png",
 			"new image content 1".getBytes()
@@ -508,8 +507,12 @@ public class PostControllerDocsTest extends RestDocsSupport {
 				preprocessRequest(prettyPrint()),
 				requestParts(
 					partWithName("request").description("게시글 수정 요청"),
-					partWithName("nswPictures").optional()
+					partWithName("newPictures").optional()
 						.description("추가할 이미지 파일 리스트")
+				),
+				requestPartFields("request",
+					fieldWithPath("content").type(STRING).description("수정된 게시글 내용"),
+					fieldWithPath("oldPictures").type(ARRAY).description("기존 이미지 파일명 리스트")
 				)
 			));
 	}

--- a/memento/src/test/java/com/memento/server/spring/api/controller/post/PostControllerTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/controller/post/PostControllerTest.java
@@ -264,7 +264,7 @@ public class PostControllerTest extends ControllerTestSupport {
 
 		UpdatePostRequest request = UpdatePostRequest.builder()
 			.content("수정된 내용")
-			.oldPictures(new ArrayList<>(List.of(1L, 2L, 3L)))
+			.oldPictures(new ArrayList<>(List.of("test1.png", "test2.png", "test3.png")))
 			.build();
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -310,7 +310,7 @@ public class PostControllerTest extends ControllerTestSupport {
 
 		UpdatePostRequest request = UpdatePostRequest.builder()
 			.content("수정된 내용")
-			.oldPictures(new ArrayList<>(List.of(1L, 2L, 3L)))
+			.oldPictures(new ArrayList<>(List.of("test1.png", "test2.png", "test3.png")))
 			.build();
 		String requestJson = objectMapper.writeValueAsString(request);
 
@@ -360,7 +360,7 @@ public class PostControllerTest extends ControllerTestSupport {
 		String content = "a".repeat(511);
 		UpdatePostRequest request = UpdatePostRequest.builder()
 			.content(content)
-			.oldPictures(new ArrayList<>(List.of(1L, 2L, 3L)))
+			.oldPictures(new ArrayList<>(List.of("test1.png", "test2.png", "test3.png")))
 			.build();
 		String requestJson = objectMapper.writeValueAsString(request);
 

--- a/memento/src/test/java/com/memento/server/spring/api/service/achievement/AchievementEventTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/service/achievement/AchievementEventTest.java
@@ -4,9 +4,14 @@ import static com.memento.server.config.MinioProperties.FileType.EMOJI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import javax.imageio.ImageIO;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -744,7 +749,7 @@ public class AchievementEventTest extends IntegrationsTestSupport {
 
 	@Test
 	@DisplayName("전문찍새")
-	public void postImageTest() {
+	public void postImageTest() throws IOException {
 		//given
 		Member member = MemberFixtures.member();
 		memberRepository.save(member);
@@ -778,7 +783,12 @@ public class AchievementEventTest extends IntegrationsTestSupport {
 				.build());
 		}
 
-		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", "test".getBytes());
+		BufferedImage bufferedImage = new BufferedImage(10, 10, BufferedImage.TYPE_INT_ARGB);
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ImageIO.write(bufferedImage, "png", baos);
+		byte[] imageBytes = baos.toByteArray();
+
+		MultipartFile file = new MockMultipartFile("image", "test.png", "image/png", imageBytes);
 		String url = "https://example.com/test.png";
 		given(minioService.createFile(file, MinioProperties.FileType.POST))
 			.willReturn(url);


### PR DESCRIPTION
## #️⃣ Issue Number

- close #153 

## 📝 요약(Summary)

- post 수정 request.oldPictures String(url)로 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [X]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

<img width="1314" height="475" alt="image" src="https://github.com/user-attachments/assets/9679de28-8961-4cde-8f63-77af690f0689" />

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
