### PR TITLE
Fix/171: notification memoryId, postId 오류

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/comment/CommentService.java
+++ b/memento/src/main/java/com/memento/server/api/service/comment/CommentService.java
@@ -68,9 +68,9 @@ public class CommentService {
 			ReactionFCM.of(
 				associate.getNickname(),
 				associate.getId(),
-				post.getAssociate().getId(),
 				post.getMemory().getId(),
-				post.getId()));
+				post.getId(),
+				post.getAssociate().getId()));
 	}
 
 	@Transactional
@@ -92,9 +92,9 @@ public class CommentService {
 			ReactionFCM.of(
 				associate.getNickname(),
 				associate.getId(),
-				post.getAssociate().getId(),
 				post.getMemory().getId(),
-				post.getId()));
+				post.getId(),
+				post.getAssociate().getId()));
 	}
 
 	@Transactional
@@ -115,9 +115,9 @@ public class CommentService {
 			ReactionFCM.of(
 				associate.getNickname(),
 				associate.getId(),
-				post.getAssociate().getId(),
 				post.getMemory().getId(),
-				post.getId()));
+				post.getId(),
+				post.getAssociate().getId()));
 	}
 
 	@Transactional


### PR DESCRIPTION
## #️⃣ Issue Number
close #171 

## 📝 요약(Summary)
notification memoryId, postId 오류

ReactionFCM.of()의 인자 순서를 잘못 넣어 DTO를 생성중이었습니다. 정상적으로 수정했습니다.
## 🛠️ PR 유형
- [ ]  새로운 기능 추가
- [X]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

## 📸스크린샷 (선택)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
