### PR TITLE
Feature/198 일반 회원가입 api 로직 수정

### DIFF
--- a/memento/src/docs/asciidoc/api/v1/member/signup-result.adoc
+++ b/memento/src/docs/asciidoc/api/v1/member/signup-result.adoc
@@ -1,15 +1,33 @@
-[[member-signup-result-email-test]]
-=== 회원가입 결과 처리 (이메일 링크)
+[[member-signup-page]]
+=== 회원가입 결과 페이지 (이메일 링크)
 
-관리자에게 발송된 이메일의 Accept/Reject 버튼 클릭 시 호출되는 API입니다.
+관리자에게 발송된 이메일의 Accept/Reject 버튼 클릭 시 리다이렉트되는 페이지입니다.
+이 페이지는 자동으로 POST 요청을 수행하여 회원가입 결과를 처리합니다.
 
 ==== HTTP Request
 
-include::{snippets}/member-signup-result-email/http-request.adoc[]
-include::{snippets}/member-signup-result-email/query-parameters.adoc[]
+include::{snippets}/member-signup-page/http-request.adoc[]
+include::{snippets}/member-signup-page/query-parameters.adoc[]
 
 NOTE: action 파라미터 값이 `accept`면 승인, `reject`면 거절입니다.
 
 ==== HTTP Response
 
-include::{snippets}/member-signup-result-email/http-response.adoc[]
+include::{snippets}/member-signup-page/http-response.adoc[]
+
+'''
+
+[[member-signup-result]]
+=== 회원가입 결과 처리 (POST)
+
+회원가입 승인/거절을 처리하는 API입니다.
+보안 토큰 검증을 통해 유효한 요청만 처리됩니다.
+
+==== HTTP Request
+
+include::{snippets}/member-signup-result/http-request.adoc[]
+include::{snippets}/member-signup-result/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/member-signup-result/http-response.adoc[]

--- a/memento/src/main/java/com/memento/server/api/controller/member/MemberController.java
+++ b/memento/src/main/java/com/memento/server/api/controller/member/MemberController.java
@@ -1,6 +1,10 @@
 package com.memento.server.api.controller.member;
 
+import static org.springframework.http.MediaType.*;
+
 import com.memento.server.api.controller.member.dto.EmailCheckResponse;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -34,66 +40,78 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/members")
 public class MemberController {
 
-	private final MemberService memberService;
-	private final AssociateService associateService;
+    private final MemberService memberService;
+    private final AssociateService associateService;
+    private final TemplateEngine templateEngine;
 
-	@GetMapping("/check-email")
-	public ResponseEntity<EmailCheckResponse> checkDuplicateEmail(
-		@RequestParam("email")
-		@NotBlank(message = "이메일은 필수입니다.")
-		@Email(
-			message = "올바른 이메일 형식이 아닙니다.",
-			regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
-		)
-		String email
-	) {
-		return ResponseEntity.ok(memberService.checkDuplicateEmail(email));
-	}
+    @Value("${app.base-url}")
+    private String baseUrl;
 
-	@PostMapping("/signup/kakao")
-	public ResponseEntity<MemberSignUpResponse> signUp(@MemberId Long kakaoId,
-		@RequestBody MemberSignUpRequest request) {
-		return ResponseEntity.ok(
-			memberService.signUp(kakaoId, request));
-	}
+    @GetMapping("/check-email")
+    public ResponseEntity<EmailCheckResponse> checkDuplicateEmail(
+            @RequestParam("email")
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(
+                    message = "올바른 이메일 형식이 아닙니다.",
+                    regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+            )
+            String email
+    ) {
+        return ResponseEntity.ok(memberService.checkDuplicateEmail(email));
+    }
 
-	@PostMapping("/signup/normal")
-	public ResponseEntity<Void> normalSignUp(@RequestBody MemberNormalSignUpRequest request) {
-		memberService.normalSignUp(request);
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/signup/kakao")
+    public ResponseEntity<MemberSignUpResponse> signUp(@MemberId Long kakaoId,
+                                                       @RequestBody MemberSignUpRequest request) {
+        return ResponseEntity.ok(
+                memberService.signUp(kakaoId, request));
+    }
 
-	@PostMapping("/signup/result")
-	public ResponseEntity<Void> signUpResult(@RequestBody MemberSignUpResultRequest request) {
-		memberService.signUpResult(request);
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/signup/normal")
+    public ResponseEntity<Void> normalSignUp(@RequestBody MemberNormalSignUpRequest request) {
+        memberService.normalSignUp(request);
+        return ResponseEntity.ok().build();
+    }
 
-	@GetMapping("/signup/result")
-	public ResponseEntity<String> signUpResultByEmail(
-		@RequestParam("memberId") Long memberId,
-		@RequestParam("action") String action
-	) {
-		boolean isReject = "reject".equalsIgnoreCase(action);
-		memberService.signUpResult(new MemberSignUpResultRequest(memberId, isReject));
-		String message = isReject ? "회원가입이 거절되었습니다." : "회원가입이 승인되었습니다.";
-		return ResponseEntity.ok(message);
-	}
+    @PostMapping("/signup/result")
+    public ResponseEntity<Void> signUpResult(@RequestBody MemberSignUpResultRequest request) {
+        memberService.signUpResult(request);
+        return ResponseEntity.ok().build();
+    }
 
-	@PostMapping("/signin")
-	public ResponseEntity<AuthResponse> singIn(@RequestBody SignInRequest request) {
-		return ResponseEntity.ok(memberService.signIn(request));
-	}
+    @GetMapping("/signup/page")
+    public ResponseEntity<String> signUpPage(
+            @RequestParam("memberId") Long memberId,
+            @RequestParam("action") String action,
+            @RequestParam("token") String token
+    ) {
+        return ResponseEntity.ok().contentType(TEXT_HTML)
+                .body(templateEngine.process("email/signup-result-page", getContext(memberId, action, token)));
+    }
 
-	@PutMapping
-	public ResponseEntity<Void> update(@MemberId Long memberId, @RequestBody MemberUpdateRequest request) {
-		memberService.update(memberId, request.name(), request.email());
-		return ResponseEntity.ok().build();
-	}
+    @PostMapping("/signin")
+    public ResponseEntity<AuthResponse> singIn(@RequestBody SignInRequest request) {
+        return ResponseEntity.ok(memberService.signIn(request));
+    }
 
-	// todo 지금 안씀
-	@GetMapping("/associates")
-	public ResponseEntity<CommunityListResponse> searchAllAssociate(@MemberId Long memberId) {
-		return ResponseEntity.ok(associateService.searchAllMyAssociate(memberId));
-	}
+    @PutMapping
+    public ResponseEntity<Void> update(@MemberId Long memberId, @RequestBody MemberUpdateRequest request) {
+        memberService.update(memberId, request.name(), request.email());
+        return ResponseEntity.ok().build();
+    }
+
+    // todo 지금 안씀
+    @GetMapping("/associates")
+    public ResponseEntity<CommunityListResponse> searchAllAssociate(@MemberId Long memberId) {
+        return ResponseEntity.ok(associateService.searchAllMyAssociate(memberId));
+    }
+
+    private Context getContext(Long memberId, String action, String token) {
+        Context context = new Context();
+        context.setVariable("memberId", memberId);
+        context.setVariable("token", token);
+        context.setVariable("action", action);
+        context.setVariable("baseUrl", baseUrl);
+        return context;
+    }
 }

--- a/memento/src/main/java/com/memento/server/api/controller/member/dto/MemberSignUpResultRequest.java
+++ b/memento/src/main/java/com/memento/server/api/controller/member/dto/MemberSignUpResultRequest.java
@@ -1,7 +1,14 @@
 package com.memento.server.api.controller.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 public record MemberSignUpResultRequest(
-	Long memberId,
-	Boolean isReject
+	@NotNull Long memberId,
+	@NotBlank String token,
+	@NotBlank String action
 ) {
+	public boolean isReject() {
+		return "reject".equalsIgnoreCase(action);
+	}
 }

--- a/memento/src/main/java/com/memento/server/api/service/email/EmailEventListener.java
+++ b/memento/src/main/java/com/memento/server/api/service/email/EmailEventListener.java
@@ -23,7 +23,8 @@ public class EmailEventListener {
 			event.memberId(),
 			event.name(),
 			event.email(),
-			event.birthday()
+			event.birthday(),
+			event.token()
 		);
 	}
 }

--- a/memento/src/main/java/com/memento/server/api/service/email/EmailService.java
+++ b/memento/src/main/java/com/memento/server/api/service/email/EmailService.java
@@ -28,7 +28,7 @@ public class EmailService {
 	@Value("${app.base-url}")
 	private String baseUrl;
 
-	public void sendSignupRequestEmail(Long memberId, String name, String email, LocalDate birthday) {
+	public void sendSignupRequestEmail(Long memberId, String name, String email, LocalDate birthday, String token) {
 		try {
 			MimeMessage message = mailSender.createMimeMessage();
 			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
@@ -36,7 +36,7 @@ public class EmailService {
 			helper.setTo(adminEmail);
 			helper.setSubject("[Memento] 새로운 회원가입 요청 - " + name);
 
-			String htmlContent = buildSignupRequestEmailContent(memberId, name, email, birthday);
+			String htmlContent = buildSignupRequestEmailContent(memberId, name, email, birthday, token);
 			helper.setText(htmlContent, true);
 
 			mailSender.send(message);
@@ -46,13 +46,14 @@ public class EmailService {
 		}
 	}
 
-	private String buildSignupRequestEmailContent(Long memberId, String name, String email, LocalDate birthday) {
+	private String buildSignupRequestEmailContent(Long memberId, String name, String email, LocalDate birthday, String token) {
 		Context context = new Context();
 		context.setVariable("memberId", memberId);
 		context.setVariable("name", name);
 		context.setVariable("email", email);
 		context.setVariable("birthday", birthday);
 		context.setVariable("baseUrl", baseUrl);
+		context.setVariable("token", token);
 
 		return templateEngine.process("email/signup-request", context);
 	}

--- a/memento/src/main/java/com/memento/server/api/service/email/dto/event/SignupRequestEvent.java
+++ b/memento/src/main/java/com/memento/server/api/service/email/dto/event/SignupRequestEvent.java
@@ -9,15 +9,17 @@ public record SignupRequestEvent(
 	Long memberId,
 	String name,
 	String email,
-	LocalDate birthday
+	LocalDate birthday,
+	String token
 ) implements EmailEvent {
 
-	public static SignupRequestEvent of(Long memberId, String name, String email, LocalDate birthday) {
+	public static SignupRequestEvent of(Long memberId, String name, String email, LocalDate birthday, String token) {
 		return SignupRequestEvent.builder()
 			.memberId(memberId)
 			.name(name)
 			.email(email)
 			.birthday(birthday)
+			.token(token)
 			.build();
 	}
 }

--- a/memento/src/main/java/com/memento/server/api/service/member/MemberService.java
+++ b/memento/src/main/java/com/memento/server/api/service/member/MemberService.java
@@ -5,6 +5,7 @@ import static com.memento.server.common.error.ErrorCodes.MEMBER_DUPLICATE;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_EMAIL_DUPLICATE;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_NOT_FOUND;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_SECRET_INVALID;
+import static com.memento.server.common.error.ErrorCodes.SIGNUP_TOKEN_INVALID;
 import static com.memento.server.common.error.ErrorCodes.SING_IN_FAIL;
 
 import com.memento.server.api.controller.member.dto.EmailCheckResponse;
@@ -133,22 +134,27 @@ public class MemberService {
 		Member member = memberRepository.save(
 			Member.createNormal(request.name(), encodedPassword, request.email(), request.birthday()));
 
-		// Redis에 fcmToken 저장
-		signupPendingRepository.save(member.getId(), request.fcmToken());
+		// Redis에 fcmToken과 보안 토큰 저장
+		String securityToken = signupPendingRepository.save(member.getId(), request.fcmToken());
 
 		// Admin에게 이메일 전송 (비동기)
 		emailEventPublisher.publish(
-			SignupRequestEvent.of(member.getId(), request.name(), request.email(), request.birthday())
+			SignupRequestEvent.of(member.getId(), request.name(), request.email(), request.birthday(), securityToken)
 		);
 	}
 
 	@Transactional
 	public void signUpResult(MemberSignUpResultRequest request) {
+		// 토큰 검증
+		if (!signupPendingRepository.verifyToken(request.memberId(), request.token())) {
+			throw new MementoException(SIGNUP_TOKEN_INVALID);
+		}
+
 		Member member = memberRepository.findByIdAndDeletedAtIsNull(request.memberId())
 			.orElseThrow(() -> new MementoException(MEMBER_NOT_FOUND));
 
 		// Redis에서 fcmToken 조회
-		Optional<String> fcmTokenOptional = signupPendingRepository.findByMemberId(request.memberId());
+		Optional<String> fcmTokenOptional = signupPendingRepository.findFcmTokenByMemberId(request.memberId());
 
 		if (request.isReject()) {
 			member.signUpReject();

--- a/memento/src/main/java/com/memento/server/common/error/ErrorCodes.java
+++ b/memento/src/main/java/com/memento/server/common/error/ErrorCodes.java
@@ -117,6 +117,8 @@ public enum ErrorCodes implements ErrorCode {
 
 	SING_IN_FAIL(BAD_REQUEST, 17000, "로그인 정보가 올바르지 않습니다."),
 
+	SIGNUP_TOKEN_INVALID(BAD_REQUEST, 18000, "유효하지 않은 회원가입 승인 요청입니다."),
+
 	;
 	private final HttpStatus status;
 	private final int code;

--- a/memento/src/main/java/com/memento/server/config/SecurityConfig.java
+++ b/memento/src/main/java/com/memento/server/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                 "/v1/health",
                 "/api/v1/members/signup/normal", "/api/v1/members/signin",
                 "/v1/members/signup/normal", "/v1/members/signin", "/api/v1/members/check-email",
-                "/api/v1/members/signup/result").permitAll()
+                "/api/v1/members/signup/page", "/api/v1/members/signup/result").permitAll()
             .requestMatchers("/error").permitAll()
             .anyRequest().authenticated())
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/memento/src/main/java/com/memento/server/config/filter/JwtFilter.java
+++ b/memento/src/main/java/com/memento/server/config/filter/JwtFilter.java
@@ -42,6 +42,7 @@ public class JwtFilter extends OncePerRequestFilter {
 		"/api/v1/members/signup/normal",
 		"/api/v1/members/signin",
 		"/api/v1/members/check-email",
+		"/api/v1/members/signup/page",
 		"/api/v1/members/signup/result",
 		"/v1/sign-in",
 		"/v1/auth/redirect",

--- a/memento/src/main/java/com/memento/server/domain/signup/SignupPendingRepository.java
+++ b/memento/src/main/java/com/memento/server/domain/signup/SignupPendingRepository.java
@@ -1,6 +1,7 @@
 package com.memento.server.domain.signup;
 
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -13,19 +14,38 @@ import lombok.RequiredArgsConstructor;
 public class SignupPendingRepository {
 
 	private static final String KEY_PREFIX = "signup:pending:";
+	private static final String FCM_TOKEN_FIELD = "fcmToken";
+	private static final String SECURITY_TOKEN_FIELD = "token";
 	private static final long TTL_DAYS = 7;
 
 	private final StringRedisTemplate redisTemplate;
 
-	public void save(Long memberId, String fcmToken) {
+	public String save(Long memberId, String fcmToken) {
 		String key = KEY_PREFIX + memberId;
-		redisTemplate.opsForValue().set(key, fcmToken, TTL_DAYS, TimeUnit.DAYS);
+		String securityToken = UUID.randomUUID().toString();
+
+		redisTemplate.opsForHash().put(key, FCM_TOKEN_FIELD, fcmToken);
+		redisTemplate.opsForHash().put(key, SECURITY_TOKEN_FIELD, securityToken);
+		redisTemplate.expire(key, TTL_DAYS, TimeUnit.DAYS);
+
+		return securityToken;
 	}
 
-	public Optional<String> findByMemberId(Long memberId) {
+	public Optional<String> findFcmTokenByMemberId(Long memberId) {
 		String key = KEY_PREFIX + memberId;
-		String fcmToken = redisTemplate.opsForValue().get(key);
-		return Optional.ofNullable(fcmToken);
+		Object fcmToken = redisTemplate.opsForHash().get(key, FCM_TOKEN_FIELD);
+		return Optional.ofNullable((String) fcmToken);
+	}
+
+	public Optional<String> findSecurityTokenByMemberId(Long memberId) {
+		String key = KEY_PREFIX + memberId;
+		Object token = redisTemplate.opsForHash().get(key, SECURITY_TOKEN_FIELD);
+		return Optional.ofNullable((String) token);
+	}
+
+	public boolean verifyToken(Long memberId, String token) {
+		Optional<String> storedToken = findSecurityTokenByMemberId(memberId);
+		return storedToken.isPresent() && storedToken.get().equals(token);
 	}
 
 	public void deleteByMemberId(Long memberId) {

--- a/memento/src/main/resources/application-local.yml
+++ b/memento/src/main/resources/application-local.yml
@@ -54,9 +54,9 @@ spring:
 
 logging:
   level:
-    root: debug
-    org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql: trace
+    root: info
+#    org.hibernate.SQL: debug
+#    org.hibernate.type.descriptor.sql: trace
 
 minio:
   url: ${MINIO_URL}

--- a/memento/src/main/resources/templates/email/signup-request.html
+++ b/memento/src/main/resources/templates/email/signup-request.html
@@ -98,11 +98,11 @@
         </table>
 
         <div class="button-container">
-            <a th:href="@{${baseUrl} + '/api/v1/members/signup/result?memberId=' + ${memberId} + '&action=accept'}"
+            <a th:href="@{${baseUrl} + '/api/v1/members/signup/page?memberId=' + ${memberId} + '&action=accept&token=' + ${token}}"
                class="button accept-button">
                 Accept
             </a>
-            <a th:href="@{${baseUrl} + '/api/v1/members/signup/result?memberId=' + ${memberId} + '&action=reject'}"
+            <a th:href="@{${baseUrl} + '/api/v1/members/signup/page?memberId=' + ${memberId} + '&action=reject&token=' + ${token}}"
                class="button reject-button">
                 Reject
             </a>

--- a/memento/src/main/resources/templates/email/signup-result-page.html
+++ b/memento/src/main/resources/templates/email/signup-result-page.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원가입 처리 중...</title>
+    <style>
+        body {
+            font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', Arial, sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background-color: #f5f5f5;
+        }
+        .container {
+            text-align: center;
+            padding: 40px;
+            background: white;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .spinner {
+            border: 4px solid #f3f3f3;
+            border-top: 4px solid #3498db;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto 20px;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        .message {
+            font-size: 18px;
+            color: #333;
+        }
+        .result {
+            display: none;
+        }
+        .success {
+            color: #27ae60;
+        }
+        .error {
+            color: #e74c3c;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div id="loading">
+            <div class="spinner"></div>
+            <p class="message">처리 중입니다...</p>
+        </div>
+        <div id="result" class="result">
+            <p id="resultMessage" class="message"></p>
+        </div>
+    </div>
+    <script th:inline="javascript">
+        const memberId = /*[[${memberId}]]*/ 0;
+        const token = /*[[${token}]]*/ '';
+        const action = /*[[${action}]]*/ '';
+        const baseUrl = /*[[${baseUrl}]]*/ '';
+
+        fetch(baseUrl + '/api/v1/members/signup/result', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ memberId: memberId, token: token, action: action })
+        })
+        .then(response => {
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('result').style.display = 'block';
+            const msg = document.getElementById('resultMessage');
+            if (response.ok) {
+                msg.textContent = action === 'reject' ? '회원가입이 거절되었습니다.' : '회원가입이 승인되었습니다.';
+                msg.classList.add('success');
+            } else {
+                msg.textContent = '처리 중 오류가 발생했습니다.';
+                msg.classList.add('error');
+            }
+        })
+        .catch(error => {
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('result').style.display = 'block';
+            const msg = document.getElementById('resultMessage');
+            msg.textContent = '처리 중 오류가 발생했습니다.';
+            msg.classList.add('error');
+        });
+    </script>
+</body>
+</html>

--- a/memento/src/test/java/com/memento/server/api/service/email/EmailServiceTest.java
+++ b/memento/src/test/java/com/memento/server/api/service/email/EmailServiceTest.java
@@ -50,12 +50,13 @@ class EmailServiceTest {
 		String name = "홍길동";
 		String email = "hong@test.com";
 		LocalDate birthday = LocalDate.of(1990, 1, 1);
+		String token = "test-token-123";
 
 		when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
 		when(templateEngine.process(any(String.class), any(Context.class))).thenReturn("<html>test</html>");
 
 		// when
-		emailService.sendSignupRequestEmail(memberId, name, email, birthday);
+		emailService.sendSignupRequestEmail(memberId, name, email, birthday, token);
 
 		// then
 		verify(mailSender, times(1)).createMimeMessage();

--- a/memento/src/test/java/com/memento/server/docs/member/MemberControllerDocsTest.java
+++ b/memento/src/test/java/com/memento/server/docs/member/MemberControllerDocsTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -51,10 +52,12 @@ public class MemberControllerDocsTest extends RestDocsSupport {
 
 	private final MemberService memberService = mock(MemberService.class);
 	private final AssociateService associateService = mock(AssociateService.class);
+	private final org.thymeleaf.TemplateEngine templateEngine = mock(org.thymeleaf.TemplateEngine.class);
 
 	@Override
 	protected Object initController() {
-		return new MemberController(memberService, associateService);
+		when(templateEngine.process(any(String.class), any())).thenReturn("<html></html>");
+		return new MemberController(memberService, associateService, templateEngine);
 	}
 	
 	// todo 지금 안씀
@@ -157,7 +160,7 @@ public class MemberControllerDocsTest extends RestDocsSupport {
 				requestFields(
 					fieldWithPath("name").type(STRING).description("이름"),
 					fieldWithPath("email").type(STRING).description("이메일"),
-					fieldWithPath("birthday").type(ARRAY).description("생일 (\"YYYY-MM-DD\""),
+					fieldWithPath("birthday").type(ARRAY).description("생일 \"YYYY-MM-DD\""),
 					fieldWithPath("password").type(STRING).description("비밀번호"),
 					fieldWithPath("secret").type(STRING).description("암호"),
 					fieldWithPath("fcmToken").type(STRING).description("fcm 토큰")
@@ -166,22 +169,43 @@ public class MemberControllerDocsTest extends RestDocsSupport {
 	}
 	
 	@Test
-	@DisplayName("회원가입 결과 처리 (이메일 링크)")
-	void signUpResultByEmail() throws Exception {
-		// given
-		doNothing().when(memberService).signUpResult(any());
-
+	@DisplayName("회원가입 결과 페이지 (이메일 링크)")
+	void signUpPage() throws Exception {
 		// when & then
-		mockMvc.perform(get("/api/v1/members/signup/result")
+		mockMvc.perform(get("/api/v1/members/signup/page")
 				.param("memberId", "1")
-				.param("action", "accept"))
+				.param("action", "accept")
+				.param("token", "test-token-123"))
 			.andExpect(status().isOk())
-			.andDo(document("member-signup-result-email",
+			.andDo(document("member-signup-page",
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				queryParameters(
 					parameterWithName("memberId").description("회원 아이디"),
-					parameterWithName("action").description("처리 액션 (accept 또는 reject)")
+					parameterWithName("action").description("처리 액션 (accept 또는 reject)"),
+					parameterWithName("token").description("보안 토큰")
+				)
+			));
+	}
+
+	@Test
+	@DisplayName("회원가입 결과 처리 (POST)")
+	void signUpResult() throws Exception {
+		// given
+		doNothing().when(memberService).signUpResult(any());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/members/signup/result")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"memberId\": 1, \"token\": \"test-token-123\", \"action\": \"accept\"}"))
+			.andExpect(status().isOk())
+			.andDo(document("member-signup-result",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestFields(
+					fieldWithPath("memberId").type(NUMBER).description("회원 아이디"),
+					fieldWithPath("token").type(STRING).description("보안 토큰"),
+					fieldWithPath("action").type(STRING).description("처리 액션 (accept 또는 reject)")
 				)
 			));
 	}

--- a/memento/src/test/java/com/memento/server/domain/signup/SignupPendingRepositoryTest.java
+++ b/memento/src/test/java/com/memento/server/domain/signup/SignupPendingRepositoryTest.java
@@ -1,9 +1,6 @@
 package com.memento.server.domain.signup;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,10 +12,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 
 @ExtendWith(MockitoExtension.class)
 class SignupPendingRepositoryTest {
@@ -29,7 +27,7 @@ class SignupPendingRepositoryTest {
 	private StringRedisTemplate redisTemplate;
 
 	@Mock
-	private ValueOperations<String, String> valueOperations;
+	private HashOperations<String, Object, Object> hashOperations;
 
 	@BeforeEach
 	void setUp() {
@@ -37,33 +35,37 @@ class SignupPendingRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 대기 정보를 저장한다.")
+	@DisplayName("회원가입 대기 정보를 저장하고 보안 토큰을 반환한다.")
 	void save() {
 		// given
 		Long memberId = 1L;
 		String fcmToken = "fcm-token-123";
 
-		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
 
 		// when
-		signupPendingRepository.save(memberId, fcmToken);
+		String securityToken = signupPendingRepository.save(memberId, fcmToken);
 
 		// then
-		verify(valueOperations).set(eq("signup:pending:1"), eq(fcmToken), eq(7L), eq(TimeUnit.DAYS));
+		assertThat(securityToken).isNotNull();
+		assertThat(securityToken).isNotEmpty();
+		verify(hashOperations).put(eq("signup:pending:1"), eq("fcmToken"), eq(fcmToken));
+		verify(hashOperations).put(eq("signup:pending:1"), eq("token"), eq(securityToken));
+		verify(redisTemplate).expire(eq("signup:pending:1"), eq(7L), eq(TimeUnit.DAYS));
 	}
 
 	@Test
-	@DisplayName("회원가입 대기 정보를 조회한다.")
-	void findByMemberId() {
+	@DisplayName("FCM 토큰을 조회한다.")
+	void findFcmTokenByMemberId() {
 		// given
 		Long memberId = 1L;
 		String fcmToken = "fcm-token-123";
 
-		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-		when(valueOperations.get("signup:pending:1")).thenReturn(fcmToken);
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("signup:pending:1", "fcmToken")).thenReturn(fcmToken);
 
 		// when
-		Optional<String> result = signupPendingRepository.findByMemberId(memberId);
+		Optional<String> result = signupPendingRepository.findFcmTokenByMemberId(memberId);
 
 		// then
 		assertThat(result).isPresent();
@@ -71,19 +73,72 @@ class SignupPendingRepositoryTest {
 	}
 
 	@Test
+	@DisplayName("보안 토큰을 조회한다.")
+	void findSecurityTokenByMemberId() {
+		// given
+		Long memberId = 1L;
+		String securityToken = "test-security-token";
+
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("signup:pending:1", "token")).thenReturn(securityToken);
+
+		// when
+		Optional<String> result = signupPendingRepository.findSecurityTokenByMemberId(memberId);
+
+		// then
+		assertThat(result).isPresent();
+		assertThat(result.get()).isEqualTo(securityToken);
+	}
+
+	@Test
 	@DisplayName("존재하지 않는 memberId로 조회하면 빈 Optional을 반환한다.")
-	void findByMemberId_notFound() {
+	void findFcmTokenByMemberId_notFound() {
 		// given
 		Long memberId = 9999L;
 
-		when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-		when(valueOperations.get("signup:pending:9999")).thenReturn(null);
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("signup:pending:9999", "fcmToken")).thenReturn(null);
 
 		// when
-		Optional<String> result = signupPendingRepository.findByMemberId(memberId);
+		Optional<String> result = signupPendingRepository.findFcmTokenByMemberId(memberId);
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("토큰 검증에 성공한다.")
+	void verifyToken_success() {
+		// given
+		Long memberId = 1L;
+		String token = "valid-token";
+
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("signup:pending:1", "token")).thenReturn(token);
+
+		// when
+		boolean result = signupPendingRepository.verifyToken(memberId, token);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("잘못된 토큰으로 검증에 실패한다.")
+	void verifyToken_fail() {
+		// given
+		Long memberId = 1L;
+		String storedToken = "stored-token";
+		String wrongToken = "wrong-token";
+
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("signup:pending:1", "token")).thenReturn(storedToken);
+
+		// when
+		boolean result = signupPendingRepository.verifyToken(memberId, wrongToken);
+
+		// then
+		assertThat(result).isFalse();
 	}
 
 	@Test

--- a/memento/src/test/java/com/memento/server/spring/api/controller/ControllerTestSupport.java
+++ b/memento/src/test/java/com/memento/server/spring/api/controller/ControllerTestSupport.java
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.when;
 })
 @Import({TestSecurityConfig.class, JwtTokenProvider.class})
 @EnableConfigurationProperties(JwtProperties.class)
+@org.springframework.test.context.TestPropertySource(properties = {"app.base-url=http://localhost:8080"})
 public abstract class ControllerTestSupport {
 
 	@Autowired
@@ -117,6 +118,9 @@ public abstract class ControllerTestSupport {
 
 	@MockitoBean
 	protected FCMService fcmService;
+
+	@MockitoBean
+	protected org.thymeleaf.spring6.SpringTemplateEngine templateEngine;
 
 	protected RequestPostProcessor withJwt(Long memberId, Long associateId, Long communityId) {
 		when(memberClaimValidator.isValid(any())).thenReturn(true);

--- a/memento/src/test/java/com/memento/server/spring/api/controller/member/MemberControllerTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/controller/member/MemberControllerTest.java
@@ -168,50 +168,75 @@ public class MemberControllerTest extends ControllerTestSupport {
 	}
 
 	@Test
-	@DisplayName("회원가입 결과 API (GET) - 승인")
-	void signUpResultByEmail_accept() throws Exception {
+	@DisplayName("회원가입 결과 페이지 (GET) - HTML 반환")
+	void signUpPage_returnsHtml() throws Exception {
 		// given
-		doNothing().when(memberService).signUpResult(any());
+		when(templateEngine.process(any(String.class), any())).thenReturn("<html></html>");
 
 		// when & then
 		mockMvc.perform(
-				get("/api/v1/members/signup/result")
+				get("/api/v1/members/signup/page")
 					.param("memberId", "1")
-					.param("action", "accept"))
+					.param("action", "accept")
+					.param("token", "test-token-123"))
 			.andDo(print())
 			.andExpect(status().isOk());
 	}
 
 	@Test
-	@DisplayName("회원가입 결과 API (GET) - 거절")
-	void signUpResultByEmail_reject() throws Exception {
+	@DisplayName("회원가입 결과 API (POST) - 승인")
+	void signUpResult_accept() throws Exception {
 		// given
 		doNothing().when(memberService).signUpResult(any());
+		String requestBody = """
+			{"memberId": 1, "token": "test-token-123", "action": "accept"}
+			""";
 
 		// when & then
 		mockMvc.perform(
-				get("/api/v1/members/signup/result")
-					.param("memberId", "1")
-					.param("action", "reject"))
+				post("/api/v1/members/signup/result")
+					.content(requestBody)
+					.contentType(APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isOk());
 	}
 
 	@Test
-	@DisplayName("회원가입 결과 API (GET) - 회원 없음")
-	void signUpResultByEmail_memberNotFound() throws Exception {
+	@DisplayName("회원가입 결과 API (POST) - 거절")
+	void signUpResult_reject() throws Exception {
 		// given
-		doThrow(new MementoException(ErrorCodes.MEMBER_NOT_FOUND))
+		doNothing().when(memberService).signUpResult(any());
+		String requestBody = """
+			{"memberId": 1, "token": "test-token-123", "action": "reject"}
+			""";
+
+		// when & then
+		mockMvc.perform(
+				post("/api/v1/members/signup/result")
+					.content(requestBody)
+					.contentType(APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("회원가입 결과 API (POST) - 토큰 검증 실패")
+	void signUpResult_invalidToken() throws Exception {
+		// given
+		doThrow(new MementoException(ErrorCodes.SIGNUP_TOKEN_INVALID))
 			.when(memberService).signUpResult(any());
+		String requestBody = """
+			{"memberId": 1, "token": "invalid-token", "action": "accept"}
+			""";
 
 		// when & then
 		mockMvc.perform(
-				get("/api/v1/members/signup/result")
-					.param("memberId", "9999")
-					.param("action", "accept"))
+				post("/api/v1/members/signup/result")
+					.content(requestBody)
+					.contentType(APPLICATION_JSON))
 			.andDo(print())
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value(4010));
+			.andExpect(jsonPath("$.code").value(18000));
 	}
 
 }

--- a/memento/src/test/java/com/memento/server/spring/api/service/member/MemberServiceTest.java
+++ b/memento/src/test/java/com/memento/server/spring/api/service/member/MemberServiceTest.java
@@ -4,6 +4,7 @@ import static com.memento.server.common.error.ErrorCodes.MEMBER_DUPLICATE;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_EMAIL_DUPLICATE;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_NOT_FOUND;
 import static com.memento.server.common.error.ErrorCodes.MEMBER_SECRET_INVALID;
+import static com.memento.server.common.error.ErrorCodes.SIGNUP_TOKEN_INVALID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -354,11 +355,14 @@ class MemberServiceTest {
 		// given
 		Member member = memberRepository.save(
 			Member.createNormal("홍길동", "encodedPassword", "hong@test.com", LocalDate.of(1990, 1, 1)));
+		String token = "valid-token-123";
 
-		org.mockito.Mockito.when(signupPendingRepository.findByMemberId(member.getId()))
+		org.mockito.Mockito.when(signupPendingRepository.verifyToken(member.getId(), token))
+			.thenReturn(true);
+		org.mockito.Mockito.when(signupPendingRepository.findFcmTokenByMemberId(member.getId()))
 			.thenReturn(java.util.Optional.of("fcm-token-123"));
 
-		MemberSignUpResultRequest request = new MemberSignUpResultRequest(member.getId(), false);
+		MemberSignUpResultRequest request = new MemberSignUpResultRequest(member.getId(), token, "accept");
 
 		// when
 		memberService.signUpResult(request);
@@ -383,11 +387,14 @@ class MemberServiceTest {
 		// given
 		Member member = memberRepository.save(
 			Member.createNormal("홍길동", "encodedPassword", "hong@test.com", LocalDate.of(1990, 1, 1)));
+		String token = "valid-token-123";
 
-		org.mockito.Mockito.when(signupPendingRepository.findByMemberId(member.getId()))
+		org.mockito.Mockito.when(signupPendingRepository.verifyToken(member.getId(), token))
+			.thenReturn(true);
+		org.mockito.Mockito.when(signupPendingRepository.findFcmTokenByMemberId(member.getId()))
 			.thenReturn(java.util.Optional.of("fcm-token-123"));
 
-		MemberSignUpResultRequest request = new MemberSignUpResultRequest(member.getId(), true);
+		MemberSignUpResultRequest request = new MemberSignUpResultRequest(member.getId(), token, "reject");
 
 		// when
 		memberService.signUpResult(request);
@@ -407,17 +414,20 @@ class MemberServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 결과 처리 시 회원이 존재하지 않으면 MEMBER_NOT_FOUND 예외가 발생한다.")
-	void signUpResult_withInvalidMemberId_throwsException() {
+	@DisplayName("회원가입 결과 처리 시 토큰이 유효하지 않으면 SIGNUP_TOKEN_INVALID 예외가 발생한다.")
+	void signUpResult_withInvalidToken_throwsException() {
 		// given
-		MemberSignUpResultRequest request = new MemberSignUpResultRequest(9999L, false);
+		MemberSignUpResultRequest request = new MemberSignUpResultRequest(9999L, "invalid-token", "accept");
+
+		org.mockito.Mockito.when(signupPendingRepository.verifyToken(9999L, "invalid-token"))
+			.thenReturn(false);
 
 		// when & then
 		assertThatThrownBy(() -> memberService.signUpResult(request))
 			.isInstanceOf(MementoException.class)
 			.satisfies(ex -> {
 				MementoException me = (MementoException) ex;
-				assertThat(me.getErrorCode()).isEqualTo(MEMBER_NOT_FOUND);
+				assertThat(me.getErrorCode()).isEqualTo(SIGNUP_TOKEN_INVALID);
 			});
 	}
 }

--- a/memento/src/test/java/com/memento/server/spring/config/TestSecurityConfig.java
+++ b/memento/src/test/java/com/memento/server/spring/config/TestSecurityConfig.java
@@ -27,7 +27,7 @@ public class TestSecurityConfig {
 			.csrf(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
 			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers("/api/v1/sign-in", "/api/v1/auth/redirect", "api/v1/auth/refresh", "/api/v1/members/signup/normal", "/api/v1/members/signin", "/api/v1/members/check-email", "/api/v1/members/signup/result").permitAll()
+				.requestMatchers("/api/v1/sign-in", "/api/v1/auth/redirect", "api/v1/auth/refresh", "/api/v1/members/signup/normal", "/api/v1/members/signin", "/api/v1/members/check-email", "/api/v1/members/signup/page", "/api/v1/members/signup/result").permitAll()
 				.requestMatchers("/error").permitAll()
 				.anyRequest().authenticated())
 			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## #️⃣ Issue Number
#198 close

## 📝 요약(Summary)
  🎯 목적

  회원가입 승인/거절 API의 보안 취약점 수정

  🔒 문제점

  기존에는 누구나 POST /api/v1/members/signup/result에 memberId만 알면 회원가입을 승인/거절할 수 있었음

  ✅ 해결 방법

  1. Security Token 도입: 회원가입 요청 시 UUID 기반 보안 토큰을 생성하여 Redis에 저장
  2. 이메일 링크 보호: 관리자 이메일의 Accept/Reject 버튼에 토큰 포함
  3. 2단계 검증 플로우:
    - GET /signup/page → HTML 페이지 반환 (토큰을 URL에서 body로 이동)
    - 페이지에서 자동 POST /signup/result → 토큰 검증 후 처리

  📝 주요 변경사항

  | 구분   | 내용                                             |
  |--------|--------------------------------------------------|
  | Redis  | Hash 구조로 변경 (fcmToken + securityToken 저장) |
  | 이메일 | 버튼 URL에 token 파라미터 추가                   |
  | API    | GET /signup/page 엔드포인트 추가                 |
  | 검증   | POST 요청 시 토큰 검증 로직 추가                 |
  | 에러   | SIGNUP_TOKEN_INVALID (18000) 에러 코드 추가      |

  🔄 플로우

  일반 회원가입 요청
    → Redis에 fcmToken + securityToken 저장
    → 관리자에게 이메일 발송 (토큰 포함 URL)
    → 관리자가 Accept/Reject 클릭
    → GET /signup/page (HTML 반환)
    → 페이지에서 자동 POST (토큰은 body에)
    → 토큰 검증 → 승인/거절 처리


## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [x]  문서 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 📸스크린샷 (선택)

스웨거 테스트 결과 등

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
