### PR TITLE
refactor: Spring Security 표준 아키텍처 준수

### DIFF
--- a/memento/src/main/java/com/memento/server/config/JwtAuthenticationEntryPoint.java
+++ b/memento/src/main/java/com/memento/server/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.memento.server.config;
+
+import static com.memento.server.common.error.ErrorCodes.TOKEN_NOT_VALID;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.memento.server.common.error.ErrorResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 인증 실패 시 일관된 에러 응답을 반환하는 EntryPoint
+ * Spring Security 표준 아키텍처를 따름
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        AuthenticationException authException
+    ) throws IOException {
+        log.warn("인증 실패: {} - {}", request.getRequestURI(), authException.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(TOKEN_NOT_VALID);
+
+        response.setStatus(TOKEN_NOT_VALID.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/memento/src/main/java/com/memento/server/config/SecurityConfig.java
+++ b/memento/src/main/java/com/memento/server/config/SecurityConfig.java
@@ -24,51 +24,46 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final JwtFilter jwtFilter;
+    private final JwtFilter jwtFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
-  @Bean
-  public CorsConfigurationSource corsConfigurationSource() {
-    CorsConfiguration configuration = new CorsConfiguration();
-    // 허용 도메인: 로컬 개발, 배포(dev/prod)
-    configuration.addAllowedOrigin("http://localhost:3000");
-    configuration.addAllowedOrigin("https://dev.memento.ai.kr");
-    configuration.addAllowedOrigin("https://memento.ai.kr");
-    configuration.addAllowedHeader("*");
-    configuration.addAllowedMethod("*");
-    configuration.setAllowCredentials(true);
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        // 허용 도메인: 로컬 개발, 배포(dev/prod)
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("http://localhost:8080");
+        configuration.addAllowedOrigin("https://dev.memento.ai.kr");
+        configuration.addAllowedOrigin("https://memento.ai.kr");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
 
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", configuration);
-    return source;
-  }
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
-  @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    return http
-        .httpBasic(AbstractHttpConfigurer::disable)
-        .formLogin(AbstractHttpConfigurer::disable)
-        .csrf(AbstractHttpConfigurer::disable)
-        .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
-        .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
-        .authorizeHttpRequests(authorize -> authorize
-            // .requestMatchers(PathRequest.toH2Console()).permitAll()
-            .requestMatchers("/favicon.ico").permitAll()
-            // OAuth callback/entry must be public (cover legacy /v1 and /api/v1)
-            .requestMatchers("/api/v1/sign-in", "/api/v1/auth/redirect", "/api/v1/auth/refresh",
-                "/v1/sign-in", "/v1/auth/redirect", "/v1/auth/refresh", "/api/v1/health",
-                "/v1/health",
-                "/api/v1/members/signup/normal", "/api/v1/members/signin",
-                "/v1/members/signup/normal", "/v1/members/signin", "/api/v1/members/check-email",
-                "/api/v1/members/signup/page", "/api/v1/members/signup/result").permitAll()
-            .requestMatchers("/error").permitAll()
-            .anyRequest().authenticated())
-        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-        .cors(Customizer.withDefaults())
-        .build();
-  }
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+            .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(SecurityConstants.getPublicPathsArray()).permitAll()
+                .anyRequest().authenticated())
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .cors(Customizer.withDefaults())
+            .build();
+    }
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/memento/src/main/java/com/memento/server/config/SecurityConstants.java
+++ b/memento/src/main/java/com/memento/server/config/SecurityConstants.java
@@ -1,0 +1,70 @@
+package com.memento.server.config;
+
+import java.util.List;
+
+/**
+ * Security 관련 공통 상수 정의
+ * Single Source of Truth - 모든 Security 설정에서 이 상수를 참조
+ */
+public final class SecurityConstants {
+
+    private SecurityConstants() {
+        // 인스턴스화 방지
+    }
+
+    /**
+     * 인증이 필요 없는 공개 API 경로 목록
+     */
+    public static final List<String> PUBLIC_PATHS = List.of(
+        // Health check
+        "/api/v1/health",
+        "/v1/health",
+
+        // OAuth & Auth
+        "/api/v1/sign-in",
+        "/api/v1/auth/redirect",
+        "/api/v1/auth/refresh",
+        "/v1/sign-in",
+        "/v1/auth/redirect",
+        "/v1/auth/refresh",
+
+        // 일반 회원가입 관련
+        "/api/v1/members/signup/normal",
+        "/api/v1/members/signin",
+        "/api/v1/members/check-email",
+        "/api/v1/members/signup/page",
+        "/api/v1/members/signup/result",
+        "/v1/members/signup/normal",
+        "/v1/members/signin",
+        "/v1/members/check-email",
+        "/v1/members/signup/page",
+        "/v1/members/signup/result",
+
+        // Static resources
+        "/favicon.ico",
+        "/error"
+    );
+
+    /**
+     * Ant 패턴을 사용하는 공개 경로 (h2-console 등)
+     */
+    public static final List<String> PUBLIC_PATH_PATTERNS = List.of(
+        "/h2-console/**"
+    );
+
+    /**
+     * 모든 공개 경로를 String 배열로 반환 (SecurityConfig에서 사용)
+     */
+    public static String[] getPublicPathsArray() {
+        int totalSize = PUBLIC_PATHS.size() + PUBLIC_PATH_PATTERNS.size();
+        String[] result = new String[totalSize];
+        int index = 0;
+        for (String path : PUBLIC_PATHS) {
+            result[index++] = path;
+        }
+        for (String pattern : PUBLIC_PATH_PATTERNS) {
+            result[index++] = pattern;
+        }
+        return result;
+    }
+}

--- a/memento/src/main/java/com/memento/server/config/filter/JwtFilter.java
+++ b/memento/src/main/java/com/memento/server/config/filter/JwtFilter.java
@@ -1,9 +1,9 @@
 package com.memento.server.config.filter;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static com.memento.server.config.SecurityConstants.PUBLIC_PATHS;
+import static com.memento.server.config.SecurityConstants.PUBLIC_PATH_PATTERNS;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -24,88 +24,80 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * JWT 토큰 검증 필터
+ * - 토큰이 유효하면 SecurityContext에 인증 정보 설정
+ * - 토큰이 없거나 유효하지 않으면 SecurityContext를 설정하지 않음 (Spring Security가 처리)
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final MemberClaimValidator memberClaimValidator;
-	private final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberClaimValidator memberClaimValidator;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-    private static final List<String> WHITELIST = List.of(
-		"/favicon.ico",
-		"/api/v1/sign-in",
-		"/api/v1/auth/redirect",
-		"/api/v1/auth/refresh",
-		"/api/v1/health",
-		"/api/v1/members/signup/normal",
-		"/api/v1/members/signin",
-		"/api/v1/members/check-email",
-		"/api/v1/members/signup/page",
-		"/api/v1/members/signup/result",
-		"/v1/sign-in",
-		"/v1/auth/redirect",
-		"/v1/auth/refresh",
-		"/v1/health",
-		"/v1/members/signup/normal",
-		"/v1/members/signin",
-		"/h2-console/**"
-	);
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
 
-	private boolean isWhitelisted(String path) {
-		return WHITELIST.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
-	}
+        // OPTIONS 요청은 CORS preflight이므로 필터 건너뜀
+        if ("OPTIONS".equalsIgnoreCase(method)) {
+            return true;
+        }
 
-	@Override
-	protected boolean shouldNotFilter(HttpServletRequest request) {
-		String path = request.getRequestURI();
-		return WHITELIST.stream().anyMatch(p -> pathMatcher.match(p, path))
-			|| path.contains(".well-known")
-			|| path.contains("com.chrome.devtools.json");
-	}
+        // 공개 경로는 필터 건너뜀
+        boolean isPublicPath = PUBLIC_PATHS.stream().anyMatch(p -> pathMatcher.match(p, path));
 
-	@Override
-	public void doFilterInternal(
-		@NotNull HttpServletRequest request,
-		@NotNull HttpServletResponse response,
-		@NotNull FilterChain chain
-	) throws IOException, ServletException {
-		// Ensure whitelist passes through regardless of token state
-		String path = request.getRequestURI();
-		if (isWhitelisted(path)) {
-			chain.doFilter(request, response);
-			return;
-		}
+        boolean isPublicPattern = PUBLIC_PATH_PATTERNS.stream().anyMatch(p -> pathMatcher.match(p, path));
 
-		String token = resolveToken(request);
+        // 개발 도구 관련 경로
+        boolean isDevToolPath = path.contains(".well-known") || path.contains("com.chrome.devtools.json");
 
-		if (!StringUtils.hasText(token) || jwtTokenProvider.isNotValidateToken(token)) {
-			SecurityContextHolder.clearContext();
-			response.sendError(SC_UNAUTHORIZED, "토큰이 없거나 검증에 실패했습니다.");
-			return;
-		}
+        return isPublicPath || isPublicPattern || isDevToolPath;
+    }
 
-		MemberClaim memberClaim = jwtTokenProvider.extractMemberClaim(token);
-		if (memberClaim.isMember() && !memberClaimValidator.isValid(memberClaim)) {
-			SecurityContextHolder.clearContext();
-			response.sendError(SC_UNAUTHORIZED, "MemberClaim 검증에 실패했습니다.");
-			return;
-		}
+    @Override
+    public void doFilterInternal(
+        @NotNull HttpServletRequest request,
+        @NotNull HttpServletResponse response,
+        @NotNull FilterChain chain
+    ) throws IOException, ServletException {
+        String token = resolveToken(request);
 
-		MemberPrincipal memberPrincipal = MemberPrincipal.from(memberClaim);
-		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-			memberPrincipal, null, memberPrincipal.getAuthorities());
-		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        // 토큰이 없거나 유효하지 않으면 SecurityContext를 설정하지 않고 통과
+        // Spring Security가 인증되지 않은 요청으로 처리하여 AuthenticationEntryPoint 호출
+        if (!StringUtils.hasText(token) || jwtTokenProvider.isNotValidateToken(token)) {
+            SecurityContextHolder.clearContext();
+            chain.doFilter(request, response);
+            return;
+        }
 
-		chain.doFilter(request, response);
-	}
+        MemberClaim memberClaim = jwtTokenProvider.extractMemberClaim(token);
 
-	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader("Authorization");
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-			return bearerToken.substring(7);
-		}
-		return null;
-	}
+        // MemberClaim 검증 실패 시에도 인증되지 않은 상태로 처리
+        if (memberClaim.isMember() && !memberClaimValidator.isValid(memberClaim)) {
+            SecurityContextHolder.clearContext();
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 인증 성공 - SecurityContext에 인증 정보 설정
+        MemberPrincipal memberPrincipal = MemberPrincipal.from(memberClaim);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+            memberPrincipal, null, memberPrincipal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 }

--- a/memento/src/test/java/com/memento/server/spring/api/controller/ControllerTestSupport.java
+++ b/memento/src/test/java/com/memento/server/spring/api/controller/ControllerTestSupport.java
@@ -1,9 +1,11 @@
 package com.memento.server.spring.api.controller;
 
+import com.memento.server.config.JwtAuthenticationEntryPoint;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -60,9 +62,9 @@ import static org.mockito.Mockito.when;
 	MemberController.class,
 	MemoryController.class
 })
-@Import({TestSecurityConfig.class, JwtTokenProvider.class})
+@Import({TestSecurityConfig.class, JwtTokenProvider.class, JwtAuthenticationEntryPoint.class})
 @EnableConfigurationProperties(JwtProperties.class)
-@org.springframework.test.context.TestPropertySource(properties = {"app.base-url=http://localhost:8080"})
+@TestPropertySource(properties = {"app.base-url=http://localhost:8080"})
 public abstract class ControllerTestSupport {
 
 	@Autowired

--- a/memento/src/test/java/com/memento/server/spring/config/TestSecurityConfig.java
+++ b/memento/src/test/java/com/memento/server/spring/config/TestSecurityConfig.java
@@ -11,27 +11,33 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.memento.server.config.JwtAuthenticationEntryPoint;
+import com.memento.server.config.SecurityConstants;
 import com.memento.server.config.filter.JwtFilter;
 
 @TestConfiguration
 public class TestSecurityConfig {
 
-	@Autowired
-	private JwtFilter jwtFilter;
+    @Autowired
+    private JwtFilter jwtFilter;
 
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		return http
-			.httpBasic(AbstractHttpConfigurer::disable)
-			.formLogin(AbstractHttpConfigurer::disable)
-			.csrf(AbstractHttpConfigurer::disable)
-			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
-			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers("/api/v1/sign-in", "/api/v1/auth/redirect", "api/v1/auth/refresh", "/api/v1/members/signup/normal", "/api/v1/members/signin", "/api/v1/members/check-email", "/api/v1/members/signup/page", "/api/v1/members/signup/result").permitAll()
-				.requestMatchers("/error").permitAll()
-				.anyRequest().authenticated())
-			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-			.cors(Customizer.withDefaults())
-			.build();
-	}
+    @Autowired
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(SecurityConstants.getPublicPathsArray()).permitAll()
+                .anyRequest().authenticated())
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .cors(Customizer.withDefaults())
+            .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#202 

## 📝 요약(Summary)
Spring Security 인증 구조를 표준 아키텍처로 개선하여 다음 문제들을 해결했습니다:

문제점:
- SecurityConfig, JwtFilter, TestSecurityConfig 3곳에서 공개 경로를 별도로 관리하여 동기화 누락 발생
- JwtFilter에서 response.sendError() 직접 호출로 인해 Spring Security 예외 처리 체인 우회
- 결과적으로 "Unable to handle the Spring Security Exception because the response is already committed" 에러 발생
- CORS preflight(OPTIONS) 요청 처리 누락으로 회원가입 승인 페이지에서 "처리 중 오류가 발생했습니다" 에러 발생

해결:
- SecurityConstants 생성으로 공개 경로를 한 곳에서 관리 (Single Source of Truth)
- JwtAuthenticationEntryPoint 추가로 인증 실패 시 일관된 401 응답 반환
- JwtFilter에서 response.sendError() 제거하고 Spring Security가 처리하도록 위임
- OPTIONS 요청을 필터에서 건너뛰도록 처리
- 누락된 /v1/ 레거시 경로 추가 (check-email, signup/page, signup/result)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [x]  주석 추가 및 수정
- [ ]  문서 수정
- [x]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

## 📸스크린샷 (선택)

## ✅ PR Checklist
- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

---
