### PR TITLE
[BUG] Fetch Kakao OIDC public keys from JWKS (#205)

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwk.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwk.java
@@ -1,0 +1,11 @@
+package com.memento.server.api.service.oauth;
+
+public record KakaoJwk(
+	String kid,
+	String kty,
+	String alg,
+	String use,
+	String n,
+	String e
+) {
+}

--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwks.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwks.java
@@ -1,0 +1,8 @@
+package com.memento.server.api.service.oauth;
+
+import java.util.List;
+
+public record KakaoJwks(
+	List<KakaoJwk> keys
+) {
+}

--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoKeyMemory.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoKeyMemory.java
@@ -5,31 +5,48 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Component;
 
+import com.memento.server.client.oauth.KakaoClient;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
-public class KakaoKeyMemory { // todo: kauth 요청 및 캐싱으로 가져오기
+@RequiredArgsConstructor
+public class KakaoKeyMemory {
 
-	private final Map<String, PublicKey> kakaoPublicKeys = new HashMap<>();
+	// Kakao rotates JWKS keys; throttle refreshes so forged kids cannot hammer kauth
+	private static final long REFRESH_COOLDOWN_MILLIS = 60_000L;
 
-	public KakaoKeyMemory() {
-		kakaoPublicKeys.put("9f252dadd5f233f93d2fa528d12fea",
-			buildRsaPublicKey(
-				"qGWf6RVzV2pM8YqJ6by5exoixIlTvdXDfYj2v7E6xkoYmesAjp_1IYL7rzhpUYqIkWX0P4wOwAsg-Ud8PcMHggfwUNPOcqgSk1hAIHr63zSlG8xatQb17q9LrWny2HWkUVEU30PxxHsLcuzmfhbRx8kOrNfJEirIuqSyWF_OBHeEgBgYjydd_c8vPo7IiH-pijZn4ZouPsEg7wtdIX3-0ZcXXDbFkaDaqClfqmVCLNBhg3DKYDQOoyWXrpFKUXUFuk2FTCqWaQJ0GniO4p_ppkYIf4zhlwUYfXZEhm8cBo6H2EgukntDbTgnoha8kNunTPekxWTDhE5wGAt6YpT4Yw",
-				"AQAB"
-			));
-
-		kakaoPublicKeys.put("3f96980381e451efad0d2ddd30e3d3",
-			buildRsaPublicKey(
-				"q8zZ0b_MNaLd6Ny8wd4cjFomilLfFIZcmhNSc1ttx_oQdJJZt5CDHB8WWwPGBUDUyY8AmfglS9Y1qA0_fxxs-ZUWdt45jSbUxghKNYgEwSutfM5sROh3srm5TiLW4YfOvKytGW1r9TQEdLe98ork8-rNRYPybRI3SKoqpci1m1QOcvUg4xEYRvbZIWku24DNMSeheytKUz6Ni4kKOVkzfGN11rUj1IrlRR-LNA9V9ZYmeoywy3k066rD5TaZHor5bM5gIzt1B4FmUuFITpXKGQZS5Hn_Ck8Bgc8kLWGAU8TzmOzLeROosqKE0eZJ4ESLMImTb2XSEZuN1wFyL0VtJw",
-				"AQAB"
-			));
-	}
+	private final KakaoClient kakaoClient;
+	private final Map<String, PublicKey> kakaoPublicKeys = new ConcurrentHashMap<>();
+	private volatile long lastRefreshedAt = 0L;
 
 	public PublicKey getPublicKeyByKid(String kid) {
+		PublicKey cached = kakaoPublicKeys.get(kid);
+		if (cached != null) {
+			return cached;
+		}
+		refreshKeys();
+		return requireCachedKey(kid);
+	}
+
+	private synchronized void refreshKeys() {
+		if (System.currentTimeMillis() - lastRefreshedAt < REFRESH_COOLDOWN_MILLIS) {
+			return;
+		}
+		kakaoClient.getJwks().keys().forEach(this::cacheKey);
+		lastRefreshedAt = System.currentTimeMillis();
+	}
+
+	private void cacheKey(KakaoJwk jwk) {
+		kakaoPublicKeys.put(jwk.kid(), buildRsaPublicKey(jwk.n(), jwk.e()));
+	}
+
+	private PublicKey requireCachedKey(String kid) {
 		PublicKey key = kakaoPublicKeys.get(kid);
 		if (key == null) {
 			throw new IllegalArgumentException("유효하지 않은 kid 입니다.");

--- a/memento/src/main/java/com/memento/server/client/oauth/KakaoClient.java
+++ b/memento/src/main/java/com/memento/server/client/oauth/KakaoClient.java
@@ -7,6 +7,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.memento.server.api.service.oauth.KakaoJwks;
 import com.memento.server.api.service.oauth.KakaoToken;
 
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,13 @@ public class KakaoClient {
 			.queryParam("prompt", "select_account")
 			.build()
 			.toUriString();
+	}
+
+	public KakaoJwks getJwks() {
+		return restClient().get()
+			.uri(kakaoClientProperties.kauthHost() + "/.well-known/jwks.json")
+			.retrieve()
+			.body(KakaoJwks.class);
 	}
 
 	public KakaoToken getKakaoToken(String code) {

--- a/memento/src/test/java/com/memento/server/unit/oauth/KakaoKeyMemoryTest.java
+++ b/memento/src/test/java/com/memento/server/unit/oauth/KakaoKeyMemoryTest.java
@@ -1,0 +1,110 @@
+package com.memento.server.unit.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.memento.server.api.service.oauth.KakaoJwk;
+import com.memento.server.api.service.oauth.KakaoJwks;
+import com.memento.server.api.service.oauth.KakaoKeyMemory;
+import com.memento.server.client.oauth.KakaoClient;
+
+public class KakaoKeyMemoryTest {
+
+	private KakaoClient kakaoClient;
+	private KakaoKeyMemory kakaoKeyMemory;
+	private RSAPublicKey rsaPublicKey;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		kakaoClient = mock(KakaoClient.class);
+		kakaoKeyMemory = new KakaoKeyMemory(kakaoClient);
+
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		KeyPair keyPair = generator.generateKeyPair();
+		rsaPublicKey = (RSAPublicKey)keyPair.getPublic();
+	}
+
+	@Test
+	@DisplayName("캐시에 없는 kid면 JWKS를 조회해 키를 반환한다")
+	void refreshOnUnknownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("rotated-kid"));
+
+		// when
+		PublicKey publicKey = kakaoKeyMemory.getPublicKeyByKid("rotated-kid");
+
+		// then
+		assertThat(publicKey).isEqualTo(rsaPublicKey);
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	@Test
+	@DisplayName("캐시된 kid는 JWKS를 다시 조회하지 않는다")
+	void useCacheForKnownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("cached-kid"));
+
+		// when
+		kakaoKeyMemory.getPublicKeyByKid("cached-kid");
+		kakaoKeyMemory.getPublicKeyByKid("cached-kid");
+
+		// then
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	@Test
+	@DisplayName("JWKS 갱신 후에도 없는 kid면 예외를 던진다")
+	void throwOnStillUnknownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("known-kid"));
+
+		// when // then
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("유효하지 않은 kid 입니다.");
+	}
+
+	@Test
+	@DisplayName("갱신 쿨다운 안에 들어온 미지의 kid는 JWKS를 다시 조회하지 않는다")
+	void throttleRefreshWithinCooldown() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("known-kid"));
+
+		// when
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid-1"))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid-2"))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		// then
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	private KakaoJwks jwksOf(String kid) {
+		KakaoJwk jwk = new KakaoJwk(kid, "RSA", "RS256", "sig",
+			base64Url(rsaPublicKey.getModulus()),
+			base64Url(rsaPublicKey.getPublicExponent()));
+		return new KakaoJwks(List.of(jwk));
+	}
+
+	private String base64Url(BigInteger value) {
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(value.toByteArray());
+	}
+}


### PR DESCRIPTION
## Summary
카카오 OIDC 서명 키 rotation으로 로그인이 전면 불가되던 문제를 JWKS 동적 조회·캐싱으로 해결

## Changes
- `KakaoKeyMemory`: 하드코딩된 공개키 2개 제거 → JWKS 조회 기반 캐시로 재작성
- 미지의 kid 수신 시 캐시 갱신 후 재조회 (향후 키 rotation 자동 대응)
- 갱신 쿨다운 60초 적용 — 위조 kid로 인한 kauth 호출 폭주 방지
- `KakaoClient.getJwks()` 추가 (`GET /.well-known/jwks.json`)
- `KakaoJwk` / `KakaoJwks` 응답 레코드 추가
- `KakaoKeyMemoryTest` 4건 추가 (캐시 히트 / 갱신 / 위조 kid 예외 / 스로틀)

## Flow

```mermaid
sequenceDiagram
    participant D as KakaoOpenIdDecoder
    participant M as KakaoKeyMemory
    participant C as KakaoClient
    participant K as kauth 서버

    D->>+M: getPublicKeyByKid(kid)
    alt 캐시 히트
        M-->>D: PublicKey
    else 캐시 미스
        M->>+C: getJwks()
        C->>+K: GET jwks.json
        K-->>-C: 공개키 목록
        C-->>-M: KakaoJwks
        M->>M: 키 캐싱 및 쿨다운 갱신
        M-->>-D: PublicKey 반환 또는 예외
    end
```

## Test
- [x] 단위 테스트 통과 (`KakaoKeyMemoryTest` 4건)
- [x] 전체 테스트 스위트 통과 (BUILD SUCCESSFUL)
- [x] 실제 카카오 JWKS 응답 필드 일치 확인 (curl)
- [ ] dev 배포 후 카카오 로그인 수동 테스트

Closes #205