### PR TITLE
[RELEASE] Fix Kakao login broken by OIDC key rotation

### DIFF
--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwk.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwk.java
@@ -1,0 +1,11 @@
+package com.memento.server.api.service.oauth;
+
+public record KakaoJwk(
+	String kid,
+	String kty,
+	String alg,
+	String use,
+	String n,
+	String e
+) {
+}

--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwks.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoJwks.java
@@ -1,0 +1,8 @@
+package com.memento.server.api.service.oauth;
+
+import java.util.List;
+
+public record KakaoJwks(
+	List<KakaoJwk> keys
+) {
+}

--- a/memento/src/main/java/com/memento/server/api/service/oauth/KakaoKeyMemory.java
+++ b/memento/src/main/java/com/memento/server/api/service/oauth/KakaoKeyMemory.java
@@ -5,31 +5,48 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Component;
 
+import com.memento.server.client.oauth.KakaoClient;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
-public class KakaoKeyMemory { // todo: kauth 요청 및 캐싱으로 가져오기
+@RequiredArgsConstructor
+public class KakaoKeyMemory {
 
-	private final Map<String, PublicKey> kakaoPublicKeys = new HashMap<>();
+	// Kakao rotates JWKS keys; throttle refreshes so forged kids cannot hammer kauth
+	private static final long REFRESH_COOLDOWN_MILLIS = 60_000L;
 
-	public KakaoKeyMemory() {
-		kakaoPublicKeys.put("9f252dadd5f233f93d2fa528d12fea",
-			buildRsaPublicKey(
-				"qGWf6RVzV2pM8YqJ6by5exoixIlTvdXDfYj2v7E6xkoYmesAjp_1IYL7rzhpUYqIkWX0P4wOwAsg-Ud8PcMHggfwUNPOcqgSk1hAIHr63zSlG8xatQb17q9LrWny2HWkUVEU30PxxHsLcuzmfhbRx8kOrNfJEirIuqSyWF_OBHeEgBgYjydd_c8vPo7IiH-pijZn4ZouPsEg7wtdIX3-0ZcXXDbFkaDaqClfqmVCLNBhg3DKYDQOoyWXrpFKUXUFuk2FTCqWaQJ0GniO4p_ppkYIf4zhlwUYfXZEhm8cBo6H2EgukntDbTgnoha8kNunTPekxWTDhE5wGAt6YpT4Yw",
-				"AQAB"
-			));
-
-		kakaoPublicKeys.put("3f96980381e451efad0d2ddd30e3d3",
-			buildRsaPublicKey(
-				"q8zZ0b_MNaLd6Ny8wd4cjFomilLfFIZcmhNSc1ttx_oQdJJZt5CDHB8WWwPGBUDUyY8AmfglS9Y1qA0_fxxs-ZUWdt45jSbUxghKNYgEwSutfM5sROh3srm5TiLW4YfOvKytGW1r9TQEdLe98ork8-rNRYPybRI3SKoqpci1m1QOcvUg4xEYRvbZIWku24DNMSeheytKUz6Ni4kKOVkzfGN11rUj1IrlRR-LNA9V9ZYmeoywy3k066rD5TaZHor5bM5gIzt1B4FmUuFITpXKGQZS5Hn_Ck8Bgc8kLWGAU8TzmOzLeROosqKE0eZJ4ESLMImTb2XSEZuN1wFyL0VtJw",
-				"AQAB"
-			));
-	}
+	private final KakaoClient kakaoClient;
+	private final Map<String, PublicKey> kakaoPublicKeys = new ConcurrentHashMap<>();
+	private volatile long lastRefreshedAt = 0L;
 
 	public PublicKey getPublicKeyByKid(String kid) {
+		PublicKey cached = kakaoPublicKeys.get(kid);
+		if (cached != null) {
+			return cached;
+		}
+		refreshKeys();
+		return requireCachedKey(kid);
+	}
+
+	private synchronized void refreshKeys() {
+		if (System.currentTimeMillis() - lastRefreshedAt < REFRESH_COOLDOWN_MILLIS) {
+			return;
+		}
+		kakaoClient.getJwks().keys().forEach(this::cacheKey);
+		lastRefreshedAt = System.currentTimeMillis();
+	}
+
+	private void cacheKey(KakaoJwk jwk) {
+		kakaoPublicKeys.put(jwk.kid(), buildRsaPublicKey(jwk.n(), jwk.e()));
+	}
+
+	private PublicKey requireCachedKey(String kid) {
 		PublicKey key = kakaoPublicKeys.get(kid);
 		if (key == null) {
 			throw new IllegalArgumentException("유효하지 않은 kid 입니다.");

--- a/memento/src/main/java/com/memento/server/client/oauth/KakaoClient.java
+++ b/memento/src/main/java/com/memento/server/client/oauth/KakaoClient.java
@@ -7,6 +7,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import com.memento.server.api.service.oauth.KakaoJwks;
 import com.memento.server.api.service.oauth.KakaoToken;
 
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,13 @@ public class KakaoClient {
 			.queryParam("prompt", "select_account")
 			.build()
 			.toUriString();
+	}
+
+	public KakaoJwks getJwks() {
+		return restClient().get()
+			.uri(kakaoClientProperties.kauthHost() + "/.well-known/jwks.json")
+			.retrieve()
+			.body(KakaoJwks.class);
 	}
 
 	public KakaoToken getKakaoToken(String code) {

--- a/memento/src/test/java/com/memento/server/unit/oauth/KakaoKeyMemoryTest.java
+++ b/memento/src/test/java/com/memento/server/unit/oauth/KakaoKeyMemoryTest.java
@@ -1,0 +1,110 @@
+package com.memento.server.unit.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.memento.server.api.service.oauth.KakaoJwk;
+import com.memento.server.api.service.oauth.KakaoJwks;
+import com.memento.server.api.service.oauth.KakaoKeyMemory;
+import com.memento.server.client.oauth.KakaoClient;
+
+public class KakaoKeyMemoryTest {
+
+	private KakaoClient kakaoClient;
+	private KakaoKeyMemory kakaoKeyMemory;
+	private RSAPublicKey rsaPublicKey;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		kakaoClient = mock(KakaoClient.class);
+		kakaoKeyMemory = new KakaoKeyMemory(kakaoClient);
+
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		KeyPair keyPair = generator.generateKeyPair();
+		rsaPublicKey = (RSAPublicKey)keyPair.getPublic();
+	}
+
+	@Test
+	@DisplayName("캐시에 없는 kid면 JWKS를 조회해 키를 반환한다")
+	void refreshOnUnknownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("rotated-kid"));
+
+		// when
+		PublicKey publicKey = kakaoKeyMemory.getPublicKeyByKid("rotated-kid");
+
+		// then
+		assertThat(publicKey).isEqualTo(rsaPublicKey);
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	@Test
+	@DisplayName("캐시된 kid는 JWKS를 다시 조회하지 않는다")
+	void useCacheForKnownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("cached-kid"));
+
+		// when
+		kakaoKeyMemory.getPublicKeyByKid("cached-kid");
+		kakaoKeyMemory.getPublicKeyByKid("cached-kid");
+
+		// then
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	@Test
+	@DisplayName("JWKS 갱신 후에도 없는 kid면 예외를 던진다")
+	void throwOnStillUnknownKid() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("known-kid"));
+
+		// when // then
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("유효하지 않은 kid 입니다.");
+	}
+
+	@Test
+	@DisplayName("갱신 쿨다운 안에 들어온 미지의 kid는 JWKS를 다시 조회하지 않는다")
+	void throttleRefreshWithinCooldown() {
+		// given
+		when(kakaoClient.getJwks()).thenReturn(jwksOf("known-kid"));
+
+		// when
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid-1"))
+			.isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> kakaoKeyMemory.getPublicKeyByKid("forged-kid-2"))
+			.isInstanceOf(IllegalArgumentException.class);
+
+		// then
+		verify(kakaoClient, times(1)).getJwks();
+	}
+
+	private KakaoJwks jwksOf(String kid) {
+		KakaoJwk jwk = new KakaoJwk(kid, "RSA", "RS256", "sig",
+			base64Url(rsaPublicKey.getModulus()),
+			base64Url(rsaPublicKey.getPublicExponent()));
+		return new KakaoJwks(List.of(jwk));
+	}
+
+	private String base64Url(BigInteger value) {
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(value.toByteArray());
+	}
+}


### PR DESCRIPTION
## Summary
카카오 OIDC 서명 키 rotation으로 prod 로그인이 전면 불가된 장애 수정 배포

## Included Changes
- #206 — `KakaoKeyMemory` 하드코딩 키 제거, JWKS 동적 조회·캐싱 (Closes #205)
- 이번 릴리즈에 포함되는 변경은 위 1건뿐입니다 (`origin/main..origin/develop` 확인)

## Verification
- [x] 단위 테스트 4건 + 전체 테스트 스위트 통과
- [x] dev 배포 완료 (`app-local:20260727071809-3062ec8-dev-dev`), health 200 확인
- [ ] merge 후 prod 카카오 로그인 확인

## Rollback
배포 실패 시 `deploy_backend.sh`가 이전 태그(`app-local:20260214070532-41be2cb-prod-prod`)로 자동 롤백